### PR TITLE
force add coordinator in pool managers

### DIFF
--- a/grants-stack/packages/common/src/allo/backends/allo-v2.ts
+++ b/grants-stack/packages/common/src/allo/backends/allo-v2.ts
@@ -464,7 +464,7 @@ export class AlloV2 implements Allo {
 
       const pubk = PubKey.deserialize(CoordinatorKeypair as string);
 
-      const address = getAddress(
+      const coordinator = getAddress(
         args.roundData.roundMetadataWithProgramContractAddress?.maciParameters
           ?.coordinatorAddress as string
       ) as Address;
@@ -504,7 +504,7 @@ export class AlloV2 implements Allo {
 
       const MaciParams = [
         // coordinator:
-        address,
+        coordinator,
         // coordinatorPubKey:
         [BigInt(pubk.asContractParam().x), BigInt(pubk.asContractParam().y)],
         getClonableMACIFactoryAddress(this.chainId),
@@ -543,9 +543,12 @@ export class AlloV2 implements Allo {
         throw new Error("Program contract address is required");
       }
 
-      const managers = args.roundData.roundOperators.map((address) =>
-        getAddress(address)
+      const managersSet = new Set(
+        args.roundData.roundOperators.map((address) => getAddress(address))
       );
+      managersSet.add(coordinator);
+
+      const managers = Array.from(managersSet);
 
       const createPoolArgs: CreatePoolArgs = {
         profileId: profileId as Hex,


### PR DESCRIPTION
### Question before we merge

If we force to add the coordinator as a pool manager

1. Is he going to be able to see the program if not a member?
2. Is he going to be able to see the round in the Manager?
3. Both 1-2?
4. Only 1 or 2?